### PR TITLE
Открытие файлов без предварительного сохранения

### DIFF
--- a/get.php
+++ b/get.php
@@ -9,14 +9,31 @@ $file = $ch->getFile($id);
 if(empty($file)) exit;
 
 $name = pathinfo($file, PATHINFO_BASENAME);
+$ext = strtolower(pathinfo($file, PATHINFO_EXTENSION));
 
 if (file_exists($file)) {
  if (ob_get_level()) {
    ob_end_clean();
  }
+ switch ($ext) {
+  case "jpg":
+  case "jpeg":
+   $ctype = "image/jpeg";
+   break;
+  case "png":
+   $ctype = "image/png";
+   break;
+  case "gif":
+   $ctype = "image/gif";
+   break;
+  case "pdf":
+   $ctype = "application/pdf";
+   break;
+  default:
+   $ctype = "application/octet-stream";
+ }
  header('Content-Description: File Transfer');
- header('Content-Type: application/octet-stream');
- header('Content-Disposition: attachment; filename=' . $name);
+ header('Content-Type: '.$ctype);
  header('Content-Transfer-Encoding: binary');
  header('Expires: 0');
  header('Cache-Control: must-revalidate');


### PR DESCRIPTION
Браузеры могут показывать картинки и pdf сразу по ссылке. Для этого просто нужно слать корректный Content-Type.
Обычно это делается с помощью finfo_file(), но для этого нужен PHP 5.3+, а в требованиях указан PHP 5, поэтому сделал вот так, только для актуальных форматов.